### PR TITLE
generalize rc5 algo to `u16` and `u64` types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,62 @@ struct RC5<T: Unsigned16To64> {
     data: PhantomData<T>,
 }
 
+fn generate_block_cipher<T>(rc_5: &RC5<T>) -> Result<Vec<T>, &'static str>
+where
+    T: Unsigned16To64 + CipherMagicConstants + Copy,
+{
+    // by the protocol design, we are guaranteed that the length of the
+    // key block is less than 255 = 2^8 - 1
+    let mut l = if rc_5.key.is_empty() {
+        return Err("key must not be empty");
+    } else {
+        (0..(rc_5.key.len() as u8))
+            .step_by(rc_5.words)
+            .map(|i| {
+                let slice = T::copy_from_slice(&rc_5.key, i as usize, i as usize + 4);
+                T::from_le_bytes(slice)
+            })
+            .collect::<Vec<T>>()
+    };
+
+    let p_w = T::P_W; // first magic number
+    let q_w = T::Q_W; // second magic number
+
+    let s_table = 0..(2 * (rc_5.rounds + 1));
+    let mut s_table = s_table
+        .into_iter()
+        .map(|x| T::from_usize(x).wrapping_mul(q_w).wrapping_add(p_w))
+        .collect::<Vec<T>>();
+
+    let mut i = T::zero().to_usize();
+    let mut j = T::zero().to_usize();
+
+    let mut a_block = T::zero();
+    let mut b_block = T::zero();
+
+    let l_len = l.len();
+    let s_len = s_table.len();
+
+    let max_iters = max(s_len, l_len);
+
+    for _ in 0..(3 * max_iters) {
+        a_block = s_table[i]
+            .wrapping_add(a_block)
+            .wrapping_add(b_block)
+            .rotate_left(T::from_usize(3usize));
+        b_block = (l[j].wrapping_add(a_block).wrapping_add(b_block))
+            .rotate_left(a_block.wrapping_add(b_block));
+
+        s_table[i] = a_block;
+        l[j] = b_block;
+
+        i = (i + 1) % s_len;
+        j = (j + 1) % l_len;
+    }
+
+    Ok(s_table)
+}
+
 impl<T: Unsigned16To64> RC5<T> {
     #[allow(dead_code)]
     fn new(key: Vec<u8>, words: usize, rounds: usize, bytes: usize) -> Self {
@@ -25,20 +81,18 @@ impl<T: Unsigned16To64> RC5<T> {
 }
 
 impl<T: Unsigned16To64 + CipherMagicConstants + Copy> Rc5CipherStream<T> for RC5<T> {
-    fn encode(&self, plaintext: Vec<u8>) -> Result<Vec<u8>, &'static str> {
+    fn encode(&self, plaintext: &[u8]) -> Result<Vec<u8>, &'static str> {
         if self.key.len() != self.bytes {
             return Err("invalid encryption key length");
         }
-        // get A block
-        let mut a_block = T::copy_from_slice(&plaintext, 0usize, self.words);
+
+        let mut a_block = T::copy_from_slice(plaintext, 0usize, self.words);
         let mut a_from_le_bytes = T::from_le_bytes(a_block);
 
-        // get B block
-        let mut b_block = T::copy_from_slice(&plaintext, self.words, plaintext.len());
+        let mut b_block = T::copy_from_slice(plaintext, self.words, plaintext.len());
         let mut b_from_le_bytes = T::from_le_bytes(b_block);
 
-        // let s table
-        let s_table = self.generate_block_cipher();
+        let s_table = generate_block_cipher(self)?;
 
         // initialize encryption of blocks A and B
         a_from_le_bytes = a_from_le_bytes.wrapping_add(s_table[0]);
@@ -57,27 +111,25 @@ impl<T: Unsigned16To64 + CipherMagicConstants + Copy> Rc5CipherStream<T> for RC5
         a_block = a_from_le_bytes.to_le_bytes();
         b_block = b_from_le_bytes.to_le_bytes();
 
-        let mut ciphertext = Vec::new();
+        let mut ciphertext = vec![];
         ciphertext.extend_from_slice(a_block.as_ref());
         ciphertext.extend_from_slice(b_block.as_ref());
+
         Ok(ciphertext)
     }
 
-    fn decode(&self, plaintext: Vec<u8>) -> Result<Vec<u8>, &'static str> {
+    fn decode(&self, plaintext: &[u8]) -> Result<Vec<u8>, &'static str> {
         if self.key.len() != self.bytes {
             return Err("invalid decryption key length");
         }
 
-        // get A block
-        let mut a_block = T::copy_from_slice(&plaintext, 0usize, self.words);
+        let mut a_block = T::copy_from_slice(plaintext, 0usize, self.words);
         let mut a_from_le_bytes = T::from_le_bytes(a_block);
 
-        // get B block
-        let mut b_block = T::copy_from_slice(&plaintext, self.words, plaintext.len());
+        let mut b_block = T::copy_from_slice(plaintext, self.words, plaintext.len());
         let mut b_from_le_bytes = T::from_le_bytes(b_block);
 
-        // get s table
-        let s_table = self.generate_block_cipher();
+        let s_table = generate_block_cipher(self)?;
 
         // the algorithm uses ROUND iterations, but it starts with a zeroth evaluation first
         for i in (1..(self.rounds + 1)).rev() {
@@ -98,66 +150,11 @@ impl<T: Unsigned16To64 + CipherMagicConstants + Copy> Rc5CipherStream<T> for RC5
         a_block = a_from_le_bytes.to_le_bytes();
         b_block = b_from_le_bytes.to_le_bytes();
 
-        let mut plaintext = Vec::new();
-        plaintext.extend_from_slice(a_block.as_ref());
-        plaintext.extend_from_slice(b_block.as_ref());
-
-        Ok(plaintext)
-    }
-
-    fn generate_block_cipher(&self) -> Vec<T> {
-        // by the protocol design, we are guaranteed that the length of the
-        // key block is less than 255 = 2^8 - 1
-        let mut l = if self.key.is_empty() {
-            vec![T::min()]
-        } else {
-            (0..(self.key.len() as u8))
-                .collect::<Vec<u8>>()
-                .into_iter()
-                .step_by(self.words)
-                .map(|i| {
-                    let slice = T::copy_from_slice(&self.key, i as usize, i as usize + 4);
-                    T::from_le_bytes(slice)
-                })
-                .collect::<Vec<T>>()
-        };
-
-        let p_w = T::from_str_radix(T::P_W, 16); // first magic number
-        let q_w = T::from_str_radix(T::Q_W, 16); // second magic number
-
-        let s_table = 0..(2 * (self.rounds + 1));
-        let mut s_table = s_table
-            .into_iter()
-            .map(|x| T::from_usize(x).wrapping_mul(q_w).wrapping_add(p_w))
-            .collect::<Vec<T>>();
-
-        let mut i = T::min().to_usize();
-        let mut j = T::min().to_usize();
-
-        let mut a_block = T::min();
-        let mut b_block = T::min();
-
-        let l_len = l.len();
-        let s_len = s_table.len();
-
-        let max_iters = max(s_len, l_len);
-
-        for _ in 0..(3 * max_iters) {
-            a_block = s_table[i]
-                .wrapping_add(a_block)
-                .wrapping_add(b_block)
-                .rotate_left(T::from_usize(3usize));
-            b_block = (l[j].wrapping_add(a_block).wrapping_add(b_block))
-                .rotate_left(a_block.wrapping_add(b_block));
-
-            s_table[i] = a_block;
-            l[j] = b_block;
-
-            i = (i + 1) % s_len;
-            j = (j + 1) % l_len;
-        }
-
-        s_table
+        let mut ciphertext = vec![];
+        ciphertext.extend_from_slice(a_block.as_ref());
+        ciphertext.extend_from_slice(b_block.as_ref());
+  
+        Ok(ciphertext)
     }
 }
 
@@ -179,7 +176,7 @@ mod tests {
 
         let pt = vec![0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77];
         let ct = vec![0x2D, 0xDC, 0x14, 0x9B, 0xCF, 0x08, 0x8B, 0x9E];
-        let res = rc_5.encode(pt).unwrap();
+        let res = rc_5.encode(&pt).unwrap();
         assert_eq!(ct, res);
     }
 
@@ -194,7 +191,7 @@ mod tests {
 
         let pt = vec![0xEA, 0x02, 0x47, 0x14, 0xAD, 0x5C, 0x4D, 0x84];
         let ct = vec![0x11, 0xE4, 0x3B, 0x86, 0xD2, 0x31, 0xEA, 0x64];
-        let res = rc_5.encode(pt).unwrap();
+        let res = rc_5.encode(&pt).unwrap();
         assert_eq!(ct, res);
     }
 
@@ -209,7 +206,7 @@ mod tests {
 
         let pt = vec![0x96, 0x95, 0x0D, 0xDA, 0x65, 0x4A, 0x3D, 0x62];
         let ct = vec![0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77];
-        let res = rc_5.decode(ct).unwrap();
+        let res = rc_5.decode(&ct).unwrap();
         assert!(&pt[..] == &res[..]);
     }
 
@@ -224,7 +221,7 @@ mod tests {
 
         let pt = vec![0x63, 0x8B, 0x3A, 0x5E, 0xF7, 0x2B, 0x66, 0x3F];
         let ct = vec![0xEA, 0x02, 0x47, 0x14, 0xAD, 0x5C, 0x4D, 0x84];
-        let res = rc_5.decode(ct).unwrap();
+        let res = rc_5.decode(&ct).unwrap();
         assert!(&pt[..] == &res[..]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,8 +130,8 @@ impl<T: Unsigned16To64 + CipherMagicConstants + Copy> Rc5CipherStream<T> for RC5
             .map(|x| T::from_usize(x).wrapping_mul(q_w).wrapping_add(p_w))
             .collect::<Vec<T>>();
 
-        let mut i = T::min();
-        let mut j = T::min();
+        let mut i = T::min().to_usize();
+        let mut j = T::min().to_usize();
 
         let mut a_block = T::min();
         let mut b_block = T::min();
@@ -142,18 +142,18 @@ impl<T: Unsigned16To64 + CipherMagicConstants + Copy> Rc5CipherStream<T> for RC5
         let max_iters = max(s_len, l_len);
 
         for _ in 0..(3 * max_iters) {
-            a_block = s_table[i.to_usize()]
+            a_block = s_table[i]
                 .wrapping_add(a_block)
                 .wrapping_add(b_block)
                 .rotate_left(T::from_usize(3usize));
-            b_block = (l[j.to_usize()].wrapping_add(a_block).wrapping_add(b_block))
+            b_block = (l[j].wrapping_add(a_block).wrapping_add(b_block))
                 .rotate_left(a_block.wrapping_add(b_block));
 
-            s_table[i.to_usize()] = a_block;
-            l[j.to_usize()] = b_block;
+            s_table[i] = a_block;
+            l[j] = b_block;
 
-            i = T::from_usize((i.to_usize() + 1) % s_len);
-            j = T::from_usize((j.to_usize() + 1) % l_len);
+            i = (i + 1) % s_len;
+            j = (j + 1) % l_len;
         }
 
         s_table

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ struct RC5<T: Unsigned16To64> {
 }
 
 impl<T: Unsigned16To64> RC5<T> {
+    #[allow(dead_code)]
     fn new(key: Vec<u8>, words: usize, rounds: usize, bytes: usize) -> Self {
         RC5 {
             key,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,113 +1,7 @@
 use std::cmp::max;
 use std::marker::PhantomData;
-use std::convert::TryInto;
-
-// represents either one of the types `u16`, `u32` or `u64`
-trait Unsigned16To64 {
-    type Bytes: Clone + Copy + AsRef<[u8]> + AsMut<[u8]>;
-    fn copy_from_slice(plaintext: &[u8], start: usize, end: usize) -> Self::Bytes;
-    fn from_le_bytes(bytes: Self::Bytes) -> Self;
-    fn to_le_bytes(self) -> Self::Bytes;
-    fn wrapping_add(self, other: Self) -> Self;
-    fn wrapping_sub(self, other: Self) -> Self;
-    fn wrapping_mul(self, other: Self) -> Self;
-    fn rotate_left(self, other: Self) -> Self;
-    fn rotate_right(self, other: Self) -> Self;
-    fn xor(self, other: Self) -> Self;
-    fn min() -> Self;
-    fn from_str_radix(val: &str, base: u32) -> Self;
-    fn from_usize(val: usize) -> Self;
-    fn to_usize(&self) -> usize;
-}
-
-macro_rules! impl_unsigned_16_to_64 {
-    ($($ty:ty),*) => { $(
-        impl Unsigned16To64 for $ty {
-            type Bytes = [u8; std::mem::size_of::<Self>()];
-
-            fn copy_from_slice(plaintext: &[u8], start: usize, end: usize) -> Self::Bytes {
-                let mut output = [0u8; std::mem::size_of::<Self>()];
-                output.copy_from_slice(plaintext[start..end].as_ref());
-                output
-            }
-
-            fn from_le_bytes(bytes: Self::Bytes) -> Self {
-                <$ty>::from_le_bytes(bytes)
-            }
-
-            fn to_le_bytes(self) -> Self::Bytes {
-                self.to_le_bytes()
-            }
-
-            fn wrapping_add(self, other: Self) -> Self {
-                self.wrapping_add(other)
-            }
-
-            fn wrapping_sub(self, other: Self) -> Self {
-                self.wrapping_sub(other)
-            }
-
-            fn wrapping_mul(self, other: Self) -> Self {
-                self.wrapping_mul(other)
-            }
-
-            fn rotate_left(self, other: Self) -> Self {
-                self.rotate_left(other.try_into().unwrap())
-            }
-
-            fn rotate_right(self, other: Self) -> Self {
-                self.rotate_right(other.try_into().unwrap())
-            }
-
-            fn xor(self, other: Self) -> Self {
-                self ^ other
-            }
-
-            fn min() -> Self {
-                Self::MIN
-            }
-
-            fn from_str_radix(val: &str, base: u32) -> Self {
-                Self::from_str_radix(val, base).unwrap()
-            }
-
-            fn from_usize(val: usize) -> Self {
-                val as Self
-            }
-
-            fn to_usize(&self) -> usize {
-                *self as usize
-            }
-        }
-    )* }
-}
-impl_unsigned_16_to_64!(u16, u32, u64);
-
-impl CipherMagicConstants for u16 {
-    const P_W: &'static str = "b7e1"; // first magic number
-    const Q_W: &'static str = "9e37"; // second magic number
-}
-
-impl CipherMagicConstants for u32 {
-    const P_W: &'static str = "b7e15163"; // first magic number
-    const Q_W: &'static str = "9e3779b9"; // second magic number
-}
-
-impl CipherMagicConstants for u64 {
-    const P_W: &'static str = "b7e151628aed2a6b"; // fist magic number
-    const Q_W: &'static str = "9e3779b97f47c15"; // second magic number
-}
-
-trait Rc5CipherStream<T: Unsigned16To64> {
-    fn encode(&self, plaintext: Vec<u8>) -> Result<Vec<u8>, &'static str>;
-    fn decode(&self, plaintext: Vec<u8>) -> Result<Vec<u8>, &'static str>;
-    fn generate_block_cipher(&self) -> Vec<T>;
-}
-
-trait CipherMagicConstants {
-    const P_W: &'static str;
-    const Q_W: &'static str;
-}
+use traits::{CipherMagicConstants, Rc5CipherStream, Unsigned16To64};
+mod traits;
 
 struct RC5<T: Unsigned16To64> {
     key: Vec<u8>,
@@ -233,8 +127,7 @@ impl<T: Unsigned16To64 + CipherMagicConstants + Copy> Rc5CipherStream<T> for RC5
         let s_table = 0..(2 * (self.rounds + 1));
         let mut s_table = s_table
             .into_iter()
-            .map(|x| {
-                T::from_usize(x).wrapping_mul(q_w).wrapping_add(p_w)})
+            .map(|x| T::from_usize(x).wrapping_mul(q_w).wrapping_add(p_w))
             .collect::<Vec<T>>();
 
         let mut i = T::min();

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -12,7 +12,7 @@ pub trait Unsigned16To64 {
     fn rotate_left(self, other: Self) -> Self;
     fn rotate_right(self, other: Self) -> Self;
     fn xor(self, other: Self) -> Self;
-    fn min() -> Self;
+    fn zero() -> Self;
     fn from_str_radix(val: &str, base: u32) -> Self;
     fn from_usize(val: usize) -> Self;
     fn to_usize(&self) -> usize;
@@ -61,7 +61,7 @@ macro_rules! impl_unsigned_16_to_64 {
                 self ^ other
             }
 
-            fn min() -> Self {
+            fn zero() -> Self {
                 Self::MIN
             }
 
@@ -82,27 +82,26 @@ macro_rules! impl_unsigned_16_to_64 {
 impl_unsigned_16_to_64!(u16, u32, u64);
 
 pub trait CipherMagicConstants {
-    const P_W: &'static str;
-    const Q_W: &'static str;
+    const P_W: Self;
+    const Q_W: Self;
 }
 
 impl CipherMagicConstants for u16 {
-    const P_W: &'static str = "b7e1"; // first magic number
-    const Q_W: &'static str = "9e37"; // second magic number
+    const P_W: Self = 0xb7e1; // first magic number
+    const Q_W: Self = 0x9e37; // second magic number
 }
 
 impl CipherMagicConstants for u32 {
-    const P_W: &'static str = "b7e15163"; // first magic number
-    const Q_W: &'static str = "9e3779b9"; // second magic number
+    const P_W: Self = 0xb7e15163; // first magic number
+    const Q_W: Self = 0x9e3779b9; // second magic number
 }
 
 impl CipherMagicConstants for u64 {
-    const P_W: &'static str = "b7e151628aed2a6b"; // fist magic number
-    const Q_W: &'static str = "9e3779b97f47c15"; // second magic number
+    const P_W: Self = 0xb7e151628aed2a6b; // fist magic number
+    const Q_W: Self = 0x9e3779b97f47c15; // second magic number
 }
 
 pub trait Rc5CipherStream<T: Unsigned16To64> {
-    fn encode(&self, plaintext: Vec<u8>) -> Result<Vec<u8>, &'static str>;
-    fn decode(&self, plaintext: Vec<u8>) -> Result<Vec<u8>, &'static str>;
-    fn generate_block_cipher(&self) -> Vec<T>;
+    fn encode(&self, plaintext: &[u8]) -> Result<Vec<u8>, &'static str>;
+    fn decode(&self, plaintext: &[u8]) -> Result<Vec<u8>, &'static str>;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,108 @@
+use std::convert::TryInto;
+
+// represents either one of the types `u16`, `u32` or `u64`
+pub trait Unsigned16To64 {
+    type Bytes: Clone + Copy + AsRef<[u8]> + AsMut<[u8]>;
+    fn copy_from_slice(plaintext: &[u8], start: usize, end: usize) -> Self::Bytes;
+    fn from_le_bytes(bytes: Self::Bytes) -> Self;
+    fn to_le_bytes(self) -> Self::Bytes;
+    fn wrapping_add(self, other: Self) -> Self;
+    fn wrapping_sub(self, other: Self) -> Self;
+    fn wrapping_mul(self, other: Self) -> Self;
+    fn rotate_left(self, other: Self) -> Self;
+    fn rotate_right(self, other: Self) -> Self;
+    fn xor(self, other: Self) -> Self;
+    fn min() -> Self;
+    fn from_str_radix(val: &str, base: u32) -> Self;
+    fn from_usize(val: usize) -> Self;
+    fn to_usize(&self) -> usize;
+}
+
+macro_rules! impl_unsigned_16_to_64 {
+    ($($ty:ty),*) => { $(
+        impl Unsigned16To64 for $ty {
+            type Bytes = [u8; std::mem::size_of::<Self>()];
+
+            fn copy_from_slice(plaintext: &[u8], start: usize, end: usize) -> Self::Bytes {
+                let mut output = [0u8; std::mem::size_of::<Self>()];
+                output.copy_from_slice(plaintext[start..end].as_ref());
+                output
+            }
+
+            fn from_le_bytes(bytes: Self::Bytes) -> Self {
+                <$ty>::from_le_bytes(bytes)
+            }
+
+            fn to_le_bytes(self) -> Self::Bytes {
+                self.to_le_bytes()
+            }
+
+            fn wrapping_add(self, other: Self) -> Self {
+                self.wrapping_add(other)
+            }
+
+            fn wrapping_sub(self, other: Self) -> Self {
+                self.wrapping_sub(other)
+            }
+
+            fn wrapping_mul(self, other: Self) -> Self {
+                self.wrapping_mul(other)
+            }
+
+            fn rotate_left(self, other: Self) -> Self {
+                self.rotate_left(other.try_into().unwrap())
+            }
+
+            fn rotate_right(self, other: Self) -> Self {
+                self.rotate_right(other.try_into().unwrap())
+            }
+
+            fn xor(self, other: Self) -> Self {
+                self ^ other
+            }
+
+            fn min() -> Self {
+                Self::MIN
+            }
+
+            fn from_str_radix(val: &str, base: u32) -> Self {
+                Self::from_str_radix(val, base).unwrap()
+            }
+
+            fn from_usize(val: usize) -> Self {
+                val as Self
+            }
+
+            fn to_usize(&self) -> usize {
+                *self as usize
+            }
+        }
+    )* }
+}
+impl_unsigned_16_to_64!(u16, u32, u64);
+
+pub trait CipherMagicConstants {
+    const P_W: &'static str;
+    const Q_W: &'static str;
+}
+
+impl CipherMagicConstants for u16 {
+    const P_W: &'static str = "b7e1"; // first magic number
+    const Q_W: &'static str = "9e37"; // second magic number
+}
+
+impl CipherMagicConstants for u32 {
+    const P_W: &'static str = "b7e15163"; // first magic number
+    const Q_W: &'static str = "9e3779b9"; // second magic number
+}
+
+impl CipherMagicConstants for u64 {
+    const P_W: &'static str = "b7e151628aed2a6b"; // fist magic number
+    const Q_W: &'static str = "9e3779b97f47c15"; // second magic number
+}
+
+pub trait Rc5CipherStream<T: Unsigned16To64> {
+    fn encode(&self, plaintext: Vec<u8>) -> Result<Vec<u8>, &'static str>;
+    fn decode(&self, plaintext: Vec<u8>) -> Result<Vec<u8>, &'static str>;
+    fn generate_block_cipher(&self) -> Vec<T>;
+}


### PR DESCRIPTION
We rely on the highly expressive type system of the Rust programming language to generalize our initial implementation to other types than `u32`, such as `u16` and `u64`.